### PR TITLE
fix: structure addNote params with nested 'note' object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "addNote":
       const createdNoteId = await ankiRequest<number>(
         "addNote",
-        request.params.arguments,
+        { note: request.params.arguments },
       );
       return {
         toolResult: `Created note with the following ID: ${createdNoteId}`,


### PR DESCRIPTION
Fixes the `addNote` tool by sending parameters to AnkiConnect in the correct format with a nested `note` object.

Resolves #1 